### PR TITLE
 used trivy version 0.37.1, that enabled also downloading the java db.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM ghcr.io/aquasecurity/trivy:0.36.1
+FROM ghcr.io/aquasecurity/trivy:0.37.1
 
-RUN trivy image --download-db-only
+RUN trivy image --download-db-only && trivy image --download-java-db-only
 
-ENTRYPOINT [ "trivy", "image", "--skip-update" ]
+ENTRYPOINT [ "trivy", "image", "--skip-db-update", "--skip-java-db-update" ]


### PR DESCRIPTION
implements issue #12  