### PR TITLE
Add update Trivy Docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/aquasecurity/trivy:0.37.3
+FROM ghcr.io/aquasecurity/trivy:0.44.1
 
 RUN trivy image --download-db-only && trivy image --download-java-db-only
 


### PR DESCRIPTION
The Trivy Docker image it's outdated, here is a pull request with a small version update.

Thanks!